### PR TITLE
Add onDrawn callback

### DIFF
--- a/.idea/watcherTasks.xml
+++ b/.idea/watcherTasks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ProjectTasksOptions">
-    <TaskOptions isEnabled="true">
+    <TaskOptions isEnabled="false">
       <option name="arguments" value="" />
       <option name="checkSyntaxErrors" value="true" />
       <option name="description" />

--- a/frontend/ssvg.ts
+++ b/frontend/ssvg.ts
@@ -27,6 +27,7 @@ export default class SSVG {
     private readonly maxPixelRatio: number|undefined;
     private readonly useWorker: boolean = true;
     private readonly getFps: (fps: number) => void = () => {};
+    private readonly onDrawn: () => void = () => {};
 
     private hoveredElement: Element|undefined;
 
@@ -34,7 +35,8 @@ export default class SSVG {
         safeMode?: boolean,
         maxPixelRatio?: number,
         useWorker?: boolean,
-        getFps?: (fps: number) => void
+        getFps?: (fps: number) => void,
+        onDrawn?: () => void
     }) {
         if(options) {
             if(options.safeMode !== undefined) {
@@ -46,6 +48,9 @@ export default class SSVG {
             }
             if(options.getFps !== undefined) {
                 this.getFps = options.getFps;
+            }
+            if(options.onDrawn !== undefined) {
+                this.onDrawn = options.onDrawn;
             }
         }
 
@@ -71,7 +76,6 @@ export default class SSVG {
         } else {
             const raf = () => {
                 this.updateFps();
-                this.logDrawn();
                 this.updateCanvas();
                 requestAnimationFrame(raf);
             };
@@ -159,7 +163,14 @@ export default class SSVG {
                 if(this.renderer.updatePropertiesFromQueue) {
                     this.renderer.updatePropertiesFromQueue(queue);
                 }
+
+                if(Object.keys(queue).length === 0) {
+                    //requestAnimationFrame(() => this.updateCanvas());
+                    setTimeout(() => this.updateCanvas(), 1);
+                    return;
+                }
                 this.renderer.draw();
+                this.logDrawn();
             });
         }
     }
@@ -1013,6 +1024,7 @@ export default class SSVG {
         if(this.lastTenCanvasDrawTimes.length > 100) {
             this.lastTenCanvasDrawTimes.shift(); // Remove first item
         }
+        this.onDrawn();
     }
     
     private updateFps() {


### PR DESCRIPTION
In some situations, it is necessary to react every time the canvas was updated (e.g., for some post processing). Therefore, this PR introduces a new init parameter `onDrawn` taking a callback function that is triggered every time the canvas was redrawn.

The callback get's triggered within the `logDrawn` method.
Small adjustment when `logDrawn` is called inside ssvg were made.