### PR TITLE
Support for image drawing (beta status)

### DIFF
--- a/canvasworker/canvasrenderer.ts
+++ b/canvasworker/canvasrenderer.ts
@@ -42,6 +42,7 @@ export default class Canvasrenderer implements CanvasWorker {
         this.drawCircle(null, 'start');
         this.drawRect(null, 'start');
         this.drawText(null, 'start');
+        this.drawImage(null, 'start');
 
         this.drawNodeAndChildren(this.vdom.data, this.forceSingle);
 
@@ -49,6 +50,7 @@ export default class Canvasrenderer implements CanvasWorker {
         this.drawCircle(null, 'end');
         this.drawRect(null, 'end');
         this.drawText(null, 'end');
+        this.drawImage(null, 'end');
         
         this.onDrawn();
     
@@ -346,6 +348,47 @@ export default class Canvasrenderer implements CanvasWorker {
         }
         if(mode === 'end') {
             for(const currentNode of this.drawTexts) {
+                drawSingle(currentNode);
+            }
+            return;
+        }
+    }
+
+    private drawImages: VdomNode[] = [];
+
+    private drawImage(node: VdomNode, mode: ('start'|'normal'|'end'|'forcesingle') = 'normal') {
+        const drawSingle = (elData: VdomNode) => {
+            if(elData.href === '') {
+                return;
+            }
+            let fill = elData['fill'] ? elData['fill'] : elData.style['fill'];
+            if(!fill) fill = '#000';
+            this.ctx.fillStyle = fill;
+            let x = elData.x || 0;
+            let y = elData.y || 0;
+            let width = elData.width || 0;
+            let height = elData.height || 0;
+            if(elData.image) {
+                try {
+                    this.ctx.drawImage(elData.image, x, y, width, height);
+                } catch(e) {
+                    console.log(e);
+                }
+            }
+        };
+        if(mode === 'start') {
+            this.drawImages = [];
+            return;
+        }
+        if(mode === 'normal') {
+            this.drawImages.push(node);
+            return;
+        }
+        if(mode === 'forcesingle') {
+            return drawSingle(node);
+        }
+        if(mode === 'end') {
+            for(const currentNode of this.drawImages) {
                 drawSingle(currentNode);
             }
             return;

--- a/frontend/domhandler.ts
+++ b/frontend/domhandler.ts
@@ -69,6 +69,20 @@ export default class Domhandler {
         const evaluatedValue = typeof value === "function" ? value.call(<any> element, (<any> element).__data__, childIndex) : value;
         this.setAttrQueue[parentSelector][attrName][childIndex] = evaluatedValue;
 
+        
+        if(attrName === "href") {
+            try {
+                fetch(location.origin + evaluatedValue, {mode: 'cors'})
+                    .then(resp => resp.blob())
+                    .then(blob => createImageBitmap(blob))
+                    .then(bitmap => {
+                        this.checkAttrName(parentSelector, "image", false);
+                        this.setAttrQueue[parentSelector]["image"][childIndex] = bitmap;
+                    });
+            }
+            catch(e) {console.log(e);}
+        }
+
         if(attrName === 'className' || attrName.indexOf('style') !== -1) {
             // Apply classes immediately so styles can be applied correctly.
             const node = this.getNodeFromElement(element);
@@ -120,6 +134,20 @@ export default class Domhandler {
                 this.setAttrQueue[parentSelector][attrName][indexOfParent] = evaluatedValue;
             } else {
                 this.sharedArrays[parentSelector][attrName][indexOfParent] = evaluatedValue * Domhandler.BUFFER_PRECISION_FACTOR;
+            }
+
+            
+            if(attrName === "href") {
+                try {
+                    fetch(location.origin + evaluatedValue, {mode: 'cors'})
+                    .then(resp => resp.blob())
+                    .then(blob => createImageBitmap(blob))
+                    .then(bitmap => {
+                        this.checkAttrName(parentSelector, "image", useSharedArray, parentNode);
+                        this.setAttrQueue[parentSelector]["image"][indexOfParent] = bitmap;
+                    });
+                }
+                catch(e) {console.log(e);}
             }
         }
 
@@ -249,6 +277,7 @@ export default class Domhandler {
             'font-size': el.getAttribute('font-size'),
             'font': el.getAttribute('font'),
             'text-anchor': el.getAttribute('text-anchor'),
+            href: el.getAttribute('href'),
             style: {},
             styleSpecificity: {},
             children: [],

--- a/frontend/ssvg.ts
+++ b/frontend/ssvg.ts
@@ -961,7 +961,7 @@ export default class SSVG {
             }
             const distance = Math.sqrt(Math.pow(cx - x, 2) + Math.pow(cy - y, 2));
             return distance < visNode.r ? visNode : false;
-        } else if(visNode.type === 'rect') {
+        } else if(visNode.type === 'rect' || visNode.type === 'image') {
 
             let elX = visNode.x || 0;
             let elY = visNode.y || 0;

--- a/util/vdomManager.ts
+++ b/util/vdomManager.ts
@@ -14,7 +14,7 @@ export type VDOM = {
     scale: number;
 } & VdomNode;
 
-export type VdomNodeType = 'svg'|'g'|'rect'|'circle'|'path'|'title'|'tspan'|'text';
+export type VdomNodeType = 'svg'|'g'|'rect'|'circle'|'path'|'title'|'tspan'|'text'|'image';
 
 export type VdomNode = {
     style: {[styleName: string]: string},
@@ -42,6 +42,8 @@ export type VdomNode = {
     height?: number,
     textAlign?: string,
     text?: string,
+    href?: string,
+    image?: ImageBitmap,
     className?: string,
     id?: string,
 }


### PR DESCRIPTION
Added support for image drawing.

The SVG image provides only the url (`href`), hence a `ImageBitmap` object for canvas drawing must be loaded. The asynchronous nature of loading the bitmap is a bit challenging, therefore this done in the `domHandler` and not in the `canvasrenderer`.

While the code works, there seem to be a big enough offset to rattle the drawing order, i.e., the image get's drawn last even if it's not the last element in the SVG order.
Any redrawn afterwards (e.g., triggered by a transform) has then the correct order again.